### PR TITLE
feat(pkg): make project a pip installable package with cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,22 @@ Most of this library's documentation assumes `pip` and `pipenv` with python3 to 
 
 No testing has been done without these requirements. If you would like to see docs for other tools/etc please create an issue or PR.
 
+## Installation
+
+### Using Pip
+
+```
+pip install git+https://github.com/cmgriffing/autobleep.git
+```
+
+### Using Pipenv
+Clone the repo.
+
 Use this to establish the pipfile-based python env:
 
 ```
 pipenv shell
 ```
-
-## Installation
-
 ```
 pipenv install
 ```
@@ -37,6 +45,18 @@ pipenv install --ignore-pipfile
 
 ## Usage
 
+### If Installed With Pip
+```
+autobleep --input=./examples/example1.mkv --output=./output/output.mka
+```
+
+Or do it with a custom JSON file containing words to bleep.
+```
+autobleep --input=./examples/example1.mkv --output=./output/output.mka --swear_words=./examples/bleep.json
+```
+
+
+### If Installed With Pipenv
 The current way of running the application is to use this command in your pipenv shell:
 
 ```

--- a/autobleep/__init__.py
+++ b/autobleep/__init__.py
@@ -1,1 +1,3 @@
 from .autobleep import AutoBleep
+
+__version__ = "0.0.0"

--- a/autobleep/cli.py
+++ b/autobleep/cli.py
@@ -1,0 +1,23 @@
+import argparse
+
+from autobleep import AutoBleep
+
+
+def main():
+    parser = argparse.ArgumentParser(
+    prog="AutoBleep",
+    description="AutoBleep parses an audio or video file and automatically bleeps the swear words",
+    epilog="Text at the bottom of help",
+)
+
+    parser.add_argument("-i", "--input", dest="input", help="the video file to bleep")
+
+    parser.add_argument(
+    "-o", "--output", dest="output", help="the destination output file path"
+)
+    parser.add_argument(
+    "-s", "--swear_words", dest="swear_words", help="JSON file with words to bleep")
+
+    args = parser.parse_args()
+
+    AutoBleep(input=args.input, swear_words=args.swear_words)

--- a/autobleep/cli.py
+++ b/autobleep/cli.py
@@ -5,18 +5,19 @@ from autobleep import AutoBleep
 
 def main():
     parser = argparse.ArgumentParser(
-    prog="AutoBleep",
-    description="AutoBleep parses an audio or video file and automatically bleeps the swear words",
-    epilog="Text at the bottom of help",
-)
+        prog="AutoBleep",
+        description="AutoBleep parses an audio or video file and automatically bleeps the swear words",
+        epilog="Text at the bottom of help",
+    )
 
     parser.add_argument("-i", "--input", dest="input", help="the video file to bleep")
 
     parser.add_argument(
-    "-o", "--output", dest="output", help="the destination output file path"
-)
+        "-o", "--output", dest="output", help="the destination output file path"
+    )
     parser.add_argument(
-    "-s", "--swear_words", dest="swear_words", help="JSON file with words to bleep")
+        "-s", "--swear_words", dest="swear_words", help="JSON file with words to bleep"
+    )
 
     args = parser.parse_args()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "autobleep"
+version = "0.0.0"
+description = "Automatically generate bleeped audio from video files"
+readme = "README.md"
+requires-python = ">=3.8"
+license = {file = "LICENSE"}
+
+authors = [
+  {email = "cmgriffing@gmail.com"},
+  {name = "Chris Griffing"}
+]
+
+dependencies = [
+  "whisper-timestamped @ git+https://github.com/linto-ai/whisper-timestamped"
+]
+
+[project.scripts]
+autobleep = "autobleep.cli:main"


### PR DESCRIPTION
Most users will being using autobleep as a cli or in some script of their own.
No need for them to clone the repo for these usecases.

Changes allows user to pip install the autobleep project from github directly, and provide them an intuitive cli command.